### PR TITLE
大佬，发现您的项目引入了org.jsoup:jsoup@1.11.3组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.template.springboot</groupId>
     <artifactId>springboot-template-project</artifactId>
@@ -24,7 +24,7 @@
         <mybatis.version>1.3.2</mybatis.version>
         <mysql.java.version>8.0.11</mysql.java.version>
         <druid.version>1.1.10</druid.version>
-        <jsoup.version>1.11.3</jsoup.version>
+        <jsoup.version>1.14.2</jsoup.version>
         <guava.version>25.1-jre</guava.version>
         <lombok.version>1.16.18</lombok.version>
     </properties>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Github jsoup安全漏洞
缺陷组件：org.jsoup:jsoup@1.11.3
漏洞编号：CVE-2021-37714
漏洞描述：Github jsoup是一个用于处理真实世界 HTML 的 Java 库。
jsoup 1.14.2之前版本存在安全漏洞，该漏洞可导致jsoup拒绝服务。
影响范围：(∞, 1.14.2)
最小修复版本：1.14.2
缺陷组件引入路径：com.template.springboot:api@1.0-SNAPSHOT->org.jsoup:jsoup@1.11.3
```
另外我运行这个项目时，IDE的安全插件提示还有99个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p61ad2